### PR TITLE
style: :art: use `btn` class for "Tilmelding" button instead of HTML

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -30,41 +30,7 @@ Ved at deltage i projektet får jeres almen praksis:
 
 ## Tilmeld
 
-<html lang="da">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Spørgeskema</title>
-    <style>
-        /* Styling af knappen */
-        .survey-button {
-            display: inline-block;
-            padding: 15px 30px;
-            font-size: 16px;
-            font-weight: bold;
-            color: white;
-            background-color: #8B0000; /* Mørk rød farve */
-            text-align: center;
-            border-radius: 5px;
-            text-decoration: none;  /* Fjerner understregningen fra linket */
-            transition: background-color 0.3s ease;  /* Glidende ændring af baggrundsfarve ved hover */
-            margin-bottom: 20px; /* Tilføjer margin nederst på knappen */
-        }
-
-        /* Hover effekt - ændrer farven, når man holder musen over knappen */
-        .survey-button:hover {
-            background-color: #600000; /* Endnu mørkere rød ved hover */
-        }
-    </style>
-</head>
-<body>
-    <!-- Linket til spørgeskemaet -->
-    <a href="https://redcap.au.dk/surveys/?s=KMCN3FHX47YNEXPN" class="survey-button" target="_blank">
-        Tilmelding
-    </a>
-</body>
-</html>
-
+[Tilmelding](https://redcap.au.dk/surveys/?s=KMCN3FHX47YNEXPN){.btn .btn-primary}
 
 Ved at udfylde tilmeldingsformularen accepterer I, at vi behandler tilmeldingsoplysningerne i projektet.
 Tilmeldelsen er først registreret, når der er trykket på "Indsend". Efter tilmeldelse kontakter vi jer indenfor en uge for at aftale et tidspunkt for undervisning, som omhandler rekruttering af patienter og opsætning og brug af PRODIAP spørgeskemaet i Web-patient.


### PR DESCRIPTION
Hej @KatrineBruun 

Jeg har tilladt mig at ændre den måde tilmeldingsknappen bliver lavet på til at udnytte det Quarto bygger på i stedet for at skrive `HTML`. 

Som du kan se nedenfor kan det skrives på en linje i stedet for 30+. Lækkert 😁 👍 

Den gamle knap så således ud: 

![image](https://github.com/user-attachments/assets/f66b5c27-0147-4c79-8575-517fad28c1c8)


Den nye ser således ud: 

![image](https://github.com/user-attachments/assets/9c6de796-54c0-42bb-96e8-3cb1d207a1a3)

Den nye knap bl.a. har følgende fordele: 

- Nemmere at vedligeholde (fordi det er mindre kode og mere gennemskueligt)
- Ved ikke selv at skrive HTML og CSS undgår vi evt. ugennemskuelige konsekvenser, hvis nogen f.eks. bruger en anden browser

Jeg har ikke tilføjet det til selve hjemmesiden endnu, fordi jeg gerne lige ville have et “go” fra dig inden 🚀 

Hvad tænker du?